### PR TITLE
feature/products-integration-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,9 @@
 docker compose -f docker/docker-compose.yaml up -d
 ```
 
+### Subindo infra para testes de integração
+```sh
+docker compose -f docker/docker-compose-test.yaml up -d
+```
+
 ## Requisito 01

--- a/docker/docker-compose-test.yaml
+++ b/docker/docker-compose-test.yaml
@@ -1,0 +1,11 @@
+version: '3.1'
+
+services:
+  db:
+    container_name: postgres-test
+    image: postgres:13-alpine
+    environment:
+      POSTGRES_PASSWORD: docker
+      POSTGRES_DB: melifreshtest
+    ports:
+      - 5433:5432

--- a/src/main/java/br/com/mercadolivre/projetointegrador/marketplace/controller/ProductController.java
+++ b/src/main/java/br/com/mercadolivre/projetointegrador/marketplace/controller/ProductController.java
@@ -62,7 +62,8 @@ public class ProductController {
     }
 
     @DeleteMapping("/{id}")
-    public void exclude(@PathVariable Long id) throws NotFoundException {
+    public ResponseEntity<Void> exclude(@PathVariable Long id) throws NotFoundException {
        productService.delete(id);
+       return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,9 @@
+# Details for our datasource
+spring.datasource.url = jdbc:postgresql://localhost:5433/melifreshtest?createDatabaseIfNotExist=true
+spring.datasource.username = postgres
+spring.datasource.password = docker
+
+# Hibernate properties
+spring.jpa.database-platform = org.hibernate.dialect.PostgreSQL94Dialect
+spring.jpa.hibernate.ddl-auto = create
+spring.jpa.hibernate.naming.implicit-strategy = org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl

--- a/src/test/java/br/com/mercadolivre/projetointegrador/integration/controller/ProductControllerTests.java
+++ b/src/test/java/br/com/mercadolivre/projetointegrador/integration/controller/ProductControllerTests.java
@@ -1,0 +1,121 @@
+package br.com.mercadolivre.projetointegrador.integration.controller;
+
+
+import br.com.mercadolivre.projetointegrador.marketplace.model.Product;
+import br.com.mercadolivre.projetointegrador.marketplace.repository.ProductRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ActiveProfiles(profiles = "test")
+public class ProductControllerTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    Product fakeProduct;
+
+    @BeforeEach
+    public void beforeEach() {
+        fakeProduct = new Product();
+        fakeProduct.setName("new product");
+        fakeProduct.setPrice(BigDecimal.valueOf(10.0));
+        fakeProduct.setCategory("new category");
+    }
+
+    @Test
+    @DisplayName("ProductController - POST - /api/v1/fresh-products")
+    public void testCreateProduct() throws Exception {
+
+
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/fresh-products")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(fakeProduct))
+                )
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andReturn();
+    }
+
+    @Test
+    @DisplayName("ProductController - GET - /api/v1/fresh-products/{id}")
+    public void testFindProductById() throws Exception {
+        productRepository.save(fakeProduct);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/fresh-products/{id}", 1L))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.name").value("new product"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.category").value("new category"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.price").value(10.0));
+    }
+
+    @Test
+    @DisplayName("ProductController - PUT - /api/v1/fresh-products/{id}")
+    public void testUpdateProduct() throws Exception {
+        productRepository.save(fakeProduct);
+
+        Product updatedProduct = new Product();
+        updatedProduct.setName("updated product");
+        updatedProduct.setPrice(BigDecimal.valueOf(20.0));
+        updatedProduct.setCategory("updated category");
+
+        mockMvc.perform(MockMvcRequestBuilders.put("/api/v1/fresh-products/{id}", 1L)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updatedProduct))
+        )
+        .andExpect(MockMvcResultMatchers.status().isNoContent()).andReturn();
+
+        Optional<Product> productDeleted = productRepository.findById(1L);
+        Assertions.assertFalse(productDeleted.isEmpty());
+
+        Assertions.assertEquals("updated product", productDeleted.get().getName());
+        Assertions.assertEquals("updated category", productDeleted.get().getCategory());
+        Assertions.assertEquals(BigDecimal.valueOf(20.0).stripTrailingZeros(), productDeleted.get().getPrice().stripTrailingZeros());
+    }
+
+    @Test
+    @DisplayName("ProductController - GET - /api/v1/fresh-products")
+    public void testFindAll() throws Exception {
+        List<Product> response = new ArrayList<>();
+        response.add(fakeProduct);
+
+        productRepository.save(fakeProduct);
+        mockMvc.perform(MockMvcRequestBuilders.
+                        get("/api/v1/fresh-products"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.content().json(objectMapper.writeValueAsString(response))).andReturn();
+    }
+
+    @Test
+    @DisplayName("ProductController - DELETE - /api/v1/fresh-products/{id}")
+    public void testDeleteProduct() throws Exception {
+        productRepository.save(fakeProduct);
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/fresh-products/{id}", 1L))
+            .andExpect(MockMvcResultMatchers.status().isNoContent());
+
+        Optional<Product> productDeleted = productRepository.findById(1L);
+        Assertions.assertTrue(productDeleted.isEmpty());
+    }
+
+}


### PR DESCRIPTION
- Postgres by default does not have createDatabaseIfNotExists on demand by jdbc, so new docker-compose.yaml has been created for testing, including application-test.properties.
- delete method on ProductController was returning void, so it was changed to return ResponseEntity<Void>
- Implementation of integration test for ProductController