### PR TITLE
hotfix: fix tests

### DIFF
--- a/docker/docker-compose-test.yaml
+++ b/docker/docker-compose-test.yaml
@@ -9,3 +9,7 @@ services:
       POSTGRES_DB: melifreshtest
     ports:
       - 5433:5432
+  redis-tests:
+    image: redis:3.2.5-alpine
+    ports:
+      - 6380:6379

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -6,3 +6,6 @@ spring.datasource.password=docker
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQL94Dialect
 spring.jpa.hibernate.ddl-auto=create
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyJpaCompliantImpl
+# Redis properties
+spring.redis.host = localhost
+spring.redis.port = 6380


### PR DESCRIPTION
* tests were failing because redis config was missing 